### PR TITLE
Enabled clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,3 @@
+---
+Checks: 'clang-diagnostic-*,clang-analyzer-*,cppcoreguidelines-*'
+WarningsAsErrors: "*"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,18 @@
 cmake_minimum_required(VERSION 3.16)
+
 project(SimpleLogger LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_program(CMAKE_CXX_CLANG_TIDY_EXECUTABLE NAMES clang-tidy)
+if (NOT CMAKE_CXX_CLANG_TIDY_EXECUTABLE)
+  message("clang-tidy not found")
+else()
+  message("clang-tidy found")
+  set(CMAKE_CXX_CLANG_TIDY "clang-tidy")
+endif()
 
 enable_testing()
 

--- a/src/Logger/Logger.cpp
+++ b/src/Logger/Logger.cpp
@@ -2,7 +2,7 @@
 #include <utils/utils.h>
 #include <iostream>
 
-std::map<LogLevel, std::string> logLevelToString{
+std::map<LogLevel, std::string> const logLevelToString{
     {DEBUG, "DEBUG"},
     {INFO, "INFO"},
     {WARNING, "WARNING"},
@@ -66,7 +66,7 @@ void Logger::log(LogLevel messageLevel, const std::string &message)
         try
         {
             logFile << "[" << DateTimeNow() << "]"
-                    << "[" << logLevelToString[messageLevel] << "]"
+                    << "[" << logLevelToString.at(messageLevel) << "]"
                     << ": " << message << std::endl;
         }
         catch (const std::ios_base::failure &e)

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <array>
 #include <chrono>
 #include <ctime>
 #include <sstream>
@@ -6,9 +7,10 @@
 
 std::string DateTimeNow(const char *format = "%Y-%m-%d %X")
 {
+    const int kBufferSize = 80;
     auto now = std::chrono::system_clock::now();
     auto in_time_t = std::chrono::system_clock::to_time_t(now);
-    std::tm tm;
+    std::tm tm {};
 
 #ifdef _WIN32
     localtime_s(&tm, &in_time_t);
@@ -17,9 +19,9 @@ std::string DateTimeNow(const char *format = "%Y-%m-%d %X")
 #endif
 
     std::stringstream ss;
-    char buffer[80];
-    strftime(buffer, 80, format, &tm);
-    ss << buffer;
+    std::array<char, kBufferSize> buffer{};
+    strftime(buffer.data(), kBufferSize, format, &tm);
+    ss << buffer.data();
     return ss.str();
 }
 

--- a/tests/LoggerTest.cpp
+++ b/tests/LoggerTest.cpp
@@ -3,6 +3,7 @@
 #include <utils/utils.h>
 #include <cstring>
 #include <fstream>
+#include <array>
 #include <iostream>
 
 // Test that the constructor creates a log file with the correct path and extension
@@ -68,7 +69,7 @@ TEST(LoggerTest, TestLogLevels)
     std::ifstream file(filePath);
     std::string lastLine, line;
 
-    LogLevel logLevels[] = {DEBUG, INFO, WARNING, ERROR};
+    std::array<LogLevel, 4> logLevels = {DEBUG, INFO, WARNING, ERROR};
     std::map<LogLevel, std::string> logLevelToString{
         {DEBUG, "DEBUG"},
         {INFO, "INFO"},


### PR DESCRIPTION
Enabled [clang-tidy](https://clang.llvm.org/extra/clang-tidy/) 

It works on windows and linux builds. On mac os `clang-tidy` is not found, probably need to provide path too.

Clang-tidy is a static code analysis tool, it checks the codebase. There are several warnings, mostly about not following [cpp-guideline](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md)